### PR TITLE
Remove smart quotes in #warning

### DIFF
--- a/RingBuf.h
+++ b/RingBuf.h
@@ -47,7 +47,7 @@
     #else
         #define RB_ATOMIC_START {
         #define RB_ATOMIC_END }
-        #warning “This library only fully supports AVR and ESP8266 Boards.”
+        #warning "This library only fully supports AVR and ESP8266 Boards."
         #warning "Operations on the buffer in ISRs are not safe!"
     #endif
 

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=RingBuf
-version=2.0
+version=2.0.1
 author=D. Aaron Wisner (daw268@cornell.edu)
 maintainer=D. Aaron Wisner (daw268@cornell.edu)
 sentence=A C library for buffering items into a ring (circular/FIFO) buffer


### PR DESCRIPTION
Unifies the quotes used in the file.

Also crashes PlatformIO at the moment when this warning is emitted due to encoding issues..